### PR TITLE
chore(node): remove node version engince from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "files"
   ],
   "homepage": "https://github.com/interencheres/cpm-logger#readme",
-  "engines": {
-    "node": "4.2.x"
+  "engine": {
+      "node": ">=4.2"
   },
   "dependencies": {
     "bunyan": "^1.5.1",


### PR DESCRIPTION
Specifying engine in package is way too strict