### PR TITLE
feat(logger) : Add logic from APIs to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Wrapper for [node-bunyan](https://github.com/trentm/node-bunyan).
 
 ### Initialization
 ```javascript
-const logger = require("cpm-logger")(configJSON);
+const logger = require("cpm-logger").init(configJSON);
 ```
 
 ### Configuration

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
   ],
   "homepage": "https://github.com/interencheres/cpm-logger#readme",
   "engine": {
-      "node": ">=4.2"
+    "node": ">=4.2"
   },
   "dependencies": {
     "bunyan": "^1.5.1",
-    "bunyan-logstash": "^0.3.4"
+    "bunyan-logstash": "^0.3.4",
+    "morgan": "^1.9.0"
   },
   "devDependencies": {
     "jscs": "^2.5.1",


### PR DESCRIPTION
I've added a new v1.0.1 tag to the master just before this PR so that any API can choose to use the old or new cpm-logger.