### PR TITLE
fix(file) : Open file in append mode instead of write

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -23,15 +23,15 @@ function modifiedStream (config) {
         `${config.files.path}/${config.files.name}.log`,
         { flags: "a", encoding: "utf8" }
     );
-  return {
-    write: incomingLogLine => {
-        const outgoingLogLine = Object.assign(
-            JSON.parse(incomingLogLine),
-            { "@timestamp": new Date().toISOString() }
-        );
-        writableStream.write(`${JSON.stringify(outgoingLogLine, bunyan.safeCycles())}\n`);
-    }
-  };
+    return {
+        write: incomingLogLine => {
+            const outgoingLogLine = Object.assign(
+                JSON.parse(incomingLogLine),
+                { "@timestamp": new Date().toISOString() }
+            );
+            writableStream.write(`${JSON.stringify(outgoingLogLine, bunyan.safeCycles())}\n`);
+        }
+    };
 }
 
 /**

--- a/logger.js
+++ b/logger.js
@@ -19,7 +19,10 @@ const headersToLog = ["x-cpm-request-id", "x-cpm-device-id"];
  * @return {function}      Write function to be used by bunyan
  */
 function modifiedStream (config) {
-    const writableStream = fs.createWriteStream(`${config.files.path}/${config.files.name}.log`);
+    const writableStream = fs.createWriteStream(
+        `${config.files.path}/${config.files.name}.log`,
+        { flags: "a", encoding: "utf8" }
+    );
   return {
     write: incomingLogLine => {
         const outgoingLogLine = Object.assign(


### PR DESCRIPTION
Default createWriteStream open mode is write, deleting previous log file each time the node server is started.

This should ensure the log is preserved and new lines appended to the end.