### PR TITLE
feat(src) : Disable src log if env is production

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -142,7 +142,7 @@ function init (config) {
 
     const logger = bunyan.createLogger({
         name: config.name,
-        src: true,
+        src: env !== "production",
         streams: streams
     });
 


### PR DESCRIPTION
From bunyan doc : WARNING: Determining the call source info is slow. Never use this option in production.